### PR TITLE
feat: MTGエージェント機能の実装 (Phase 3)

### DIFF
--- a/backend/src/application/use_cases/agent_use_cases.py
+++ b/backend/src/application/use_cases/agent_use_cases.py
@@ -1,0 +1,98 @@
+"""Use cases for Agent management.
+
+Application layer use cases following clean architecture principles.
+"""
+
+from datetime import datetime
+from uuid import UUID, uuid4
+
+from src.domain.entities.agent import Agent
+from src.domain.repositories.agent_repository import AgentRepository
+
+
+class CreateAgentUseCase:
+    """エージェント作成ユースケース."""
+
+    def __init__(self, repository: AgentRepository) -> None:
+        self.repository = repository
+
+    def execute(
+        self,
+        user_id: UUID,
+        name: str,
+        description: str | None = None,
+        slack_channel_id: str | None = None,
+    ) -> Agent:
+        """エージェントを作成する."""
+        agent = Agent(
+            id=uuid4(),
+            user_id=user_id,
+            name=name,
+            description=description,
+            slack_channel_id=slack_channel_id,
+            created_at=datetime.now(),
+        )
+        return self.repository.create(agent)
+
+
+class GetAgentsUseCase:
+    """エージェント一覧取得ユースケース."""
+
+    def __init__(self, repository: AgentRepository) -> None:
+        self.repository = repository
+
+    def execute(self, user_id: UUID) -> list[Agent]:
+        """ユーザーの全エージェントを取得する."""
+        return self.repository.get_all(user_id)
+
+
+class GetAgentUseCase:
+    """エージェント取得ユースケース."""
+
+    def __init__(self, repository: AgentRepository) -> None:
+        self.repository = repository
+
+    def execute(self, agent_id: UUID, user_id: UUID) -> Agent | None:
+        """IDでエージェントを取得する."""
+        return self.repository.get_by_id(agent_id, user_id)
+
+
+class UpdateAgentUseCase:
+    """エージェント更新ユースケース."""
+
+    def __init__(self, repository: AgentRepository) -> None:
+        self.repository = repository
+
+    def execute(
+        self,
+        agent_id: UUID,
+        user_id: UUID,
+        name: str | None = None,
+        description: str | None = None,
+        slack_channel_id: str | None = None,
+    ) -> Agent | None:
+        """エージェントを更新する."""
+        agent = self.repository.get_by_id(agent_id, user_id)
+        if not agent:
+            return None
+
+        if name is not None:
+            agent.name = name
+        if description is not None:
+            agent.description = description
+        if slack_channel_id is not None:
+            agent.slack_channel_id = slack_channel_id
+
+        agent.updated_at = datetime.now()
+        return self.repository.update(agent)
+
+
+class DeleteAgentUseCase:
+    """エージェント削除ユースケース."""
+
+    def __init__(self, repository: AgentRepository) -> None:
+        self.repository = repository
+
+    def execute(self, agent_id: UUID, user_id: UUID) -> bool:
+        """エージェントを削除する."""
+        return self.repository.delete(agent_id, user_id)

--- a/backend/src/domain/entities/agent.py
+++ b/backend/src/domain/entities/agent.py
@@ -1,0 +1,54 @@
+"""Agent entity for domain layer.
+
+Pure Python entity without SQLAlchemy/Pydantic dependencies.
+Following ADR-0001 clean architecture principles.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID
+
+
+@dataclass
+class Agent:
+    """MTGエージェントを表すエンティティ.
+
+    Attributes:
+        id: エージェントの一意識別子
+        user_id: 所有ユーザーのID
+        name: エージェント名（MTG名）
+        description: エージェントの説明
+        slack_channel_id: 紐付けられたSlackチャンネルID
+        created_at: 作成日時
+        updated_at: 更新日時
+    """
+
+    id: UUID
+    user_id: UUID
+    name: str
+    created_at: datetime
+    description: str | None = None
+    slack_channel_id: str | None = None
+    updated_at: datetime | None = None
+
+    def update_slack_channel(self, channel_id: str | None) -> None:
+        """Slackチャンネルを紐付け/解除する.
+
+        Args:
+            channel_id: 紐付けるSlackチャンネルID。Noneの場合は紐付けを解除。
+        """
+        self.slack_channel_id = channel_id
+        self.updated_at = datetime.now()
+
+    def update_info(self, name: str | None = None, description: str | None = None) -> None:
+        """エージェント情報を更新する.
+
+        Args:
+            name: 新しいエージェント名。Noneの場合は変更しない。
+            description: 新しい説明。Noneの場合は変更しない。
+        """
+        if name is not None:
+            self.name = name
+        if description is not None:
+            self.description = description
+        self.updated_at = datetime.now()

--- a/backend/src/domain/repositories/agent_repository.py
+++ b/backend/src/domain/repositories/agent_repository.py
@@ -1,0 +1,93 @@
+"""Agent repository interface for domain layer.
+
+Abstract base class defining the contract for agent persistence operations.
+Implementations should be provided in the infrastructure layer.
+Following ADR-0001 clean architecture principles.
+"""
+
+from abc import ABC, abstractmethod
+from uuid import UUID
+
+from src.domain.entities.agent import Agent
+
+
+class AgentRepository(ABC):
+    """エージェントリポジトリのインターフェース.
+
+    DDDのRepositoryパターンに従い、エージェントの永続化操作を定義。
+    具体的な実装はインフラ層で提供される。
+    """
+
+    @abstractmethod
+    def get_by_id(self, agent_id: UUID, user_id: UUID) -> Agent | None:
+        """IDでエージェントを取得する.
+
+        Args:
+            agent_id: エージェントの一意識別子
+            user_id: 所有ユーザーのID（RLSによるアクセス制御）
+
+        Returns:
+            見つかった場合はAgentエンティティ、見つからない場合はNone
+        """
+
+    @abstractmethod
+    def get_all(self, user_id: UUID) -> list[Agent]:
+        """ユーザーの全エージェントを取得する.
+
+        Args:
+            user_id: 所有ユーザーのID
+
+        Returns:
+            Agentエンティティのリスト（作成日時の降順）
+        """
+
+    @abstractmethod
+    def create(self, agent: Agent) -> Agent:
+        """エージェントを作成する.
+
+        Args:
+            agent: 作成するAgentエンティティ
+
+        Returns:
+            作成されたAgentエンティティ
+        """
+
+    @abstractmethod
+    def update(self, agent: Agent) -> Agent:
+        """エージェントを更新する.
+
+        Args:
+            agent: 更新するAgentエンティティ
+
+        Returns:
+            更新されたAgentエンティティ
+
+        Raises:
+            ValueError: エージェントが存在しない場合
+        """
+
+    @abstractmethod
+    def delete(self, agent_id: UUID, user_id: UUID) -> bool:
+        """エージェントを削除する.
+
+        関連する議事録・アジェンダもカスケード削除される。
+
+        Args:
+            agent_id: 削除するエージェントのID
+            user_id: 所有ユーザーのID（RLSによるアクセス制御）
+
+        Returns:
+            削除成功時はTrue、見つからない場合はFalse
+        """
+
+    @abstractmethod
+    def exists(self, agent_id: UUID, user_id: UUID) -> bool:
+        """エージェントの存在を確認する.
+
+        Args:
+            agent_id: 確認するエージェントのID
+            user_id: 所有ユーザーのID
+
+        Returns:
+            存在する場合はTrue、しない場合はFalse
+        """

--- a/backend/src/infrastructure/repositories/agent_repository_impl.py
+++ b/backend/src/infrastructure/repositories/agent_repository_impl.py
@@ -1,0 +1,123 @@
+"""Agent repository implementation using Supabase.
+
+Infrastructure layer implementation of AgentRepository interface.
+Following ADR-0001 clean architecture principles.
+"""
+
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from src.domain.entities.agent import Agent
+from src.domain.repositories.agent_repository import AgentRepository
+from src.infrastructure.external.supabase_client import get_supabase_client
+
+
+class AgentRepositoryImpl(AgentRepository):
+    """エージェントリポジトリのSupabase実装."""
+
+    def __init__(self) -> None:
+        """リポジトリを初期化する."""
+        self._client = get_supabase_client()
+
+    def get_by_id(self, agent_id: UUID, user_id: UUID) -> Agent | None:
+        """IDでエージェントを取得する."""
+        if self._client is None:
+            return None
+
+        result = (
+            self._client.table("agents")
+            .select("*")
+            .eq("id", str(agent_id))
+            .eq("user_id", str(user_id))
+            .maybe_single()
+            .execute()
+        )
+
+        if result is None or not result.data:
+            return None
+
+        data: dict[str, Any] = dict(result.data)  # type: ignore[arg-type]
+        return self._to_entity(data)
+
+    def get_all(self, user_id: UUID) -> list[Agent]:
+        """ユーザーの全エージェントを取得する."""
+        if self._client is None:
+            return []
+
+        result = (
+            self._client.table("agents")
+            .select("*")
+            .eq("user_id", str(user_id))
+            .order("created_at", desc=True)
+            .execute()
+        )
+
+        return [self._to_entity(dict(row)) for row in result.data]  # type: ignore[arg-type]
+
+    def create(self, agent: Agent) -> Agent:
+        """エージェントを作成する."""
+        if self._client is None:
+            return agent
+
+        data = {
+            "id": str(agent.id),
+            "user_id": str(agent.user_id),
+            "name": agent.name,
+            "description": agent.description,
+            "slack_channel_id": agent.slack_channel_id,
+            "created_at": agent.created_at.isoformat(),
+        }
+        self._client.table("agents").insert(data).execute()
+        return agent
+
+    def update(self, agent: Agent) -> Agent:
+        """エージェントを更新する."""
+        if self._client is None:
+            return agent
+
+        data = {
+            "name": agent.name,
+            "description": agent.description,
+            "slack_channel_id": agent.slack_channel_id,
+            "updated_at": datetime.now().isoformat(),
+        }
+        self._client.table("agents").update(data).eq("id", str(agent.id)).execute()
+        return agent
+
+    def delete(self, agent_id: UUID, user_id: UUID) -> bool:
+        """エージェントを削除する."""
+        if self._client is None:
+            return False
+
+        result = self._client.table("agents").delete().eq("id", str(agent_id)).eq("user_id", str(user_id)).execute()
+        return len(result.data) > 0
+
+    def exists(self, agent_id: UUID, user_id: UUID) -> bool:
+        """エージェントの存在を確認する."""
+        if self._client is None:
+            return False
+
+        result = self._client.table("agents").select("id").eq("id", str(agent_id)).eq("user_id", str(user_id)).execute()
+        return len(result.data) > 0
+
+    def _to_entity(self, data: dict[str, Any]) -> Agent:
+        """DB結果をエンティティに変換する."""
+        created_at_str = data["created_at"]
+        updated_at_str = data.get("updated_at")
+
+        return Agent(
+            id=UUID(str(data["id"])),
+            user_id=UUID(str(data["user_id"])),
+            name=str(data["name"]),
+            description=str(data["description"]) if data.get("description") else None,
+            slack_channel_id=(str(data["slack_channel_id"]) if data.get("slack_channel_id") else None),
+            created_at=(
+                datetime.fromisoformat(str(created_at_str)) if isinstance(created_at_str, str) else datetime.now()
+            ),
+            updated_at=(
+                datetime.fromisoformat(str(updated_at_str))
+                if updated_at_str and isinstance(updated_at_str, str)
+                else None
+            ),
+        )

--- a/backend/src/presentation/api/v1/endpoints/agents.py
+++ b/backend/src/presentation/api/v1/endpoints/agents.py
@@ -1,0 +1,115 @@
+"""Agent API endpoints.
+
+REST API endpoints for agent management.
+"""
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from src.application.use_cases.agent_use_cases import (
+    CreateAgentUseCase,
+    DeleteAgentUseCase,
+    GetAgentsUseCase,
+    GetAgentUseCase,
+    UpdateAgentUseCase,
+)
+from src.domain.entities.agent import Agent
+from src.infrastructure.repositories.agent_repository_impl import AgentRepositoryImpl
+from src.presentation.api.v1.dependencies import get_current_user_id
+from src.presentation.schemas.agent import AgentCreate, AgentResponse, AgentUpdate
+
+router = APIRouter(prefix="/agents", tags=["agents"])
+
+
+def get_repository() -> AgentRepositoryImpl:
+    """リポジトリのDI."""
+    return AgentRepositoryImpl()
+
+
+def _to_response(agent: Agent) -> AgentResponse:
+    """エンティティをレスポンスに変換."""
+    return AgentResponse(
+        id=agent.id,
+        name=agent.name,
+        description=agent.description,
+        slack_channel_id=agent.slack_channel_id,
+        created_at=agent.created_at,
+        updated_at=agent.updated_at,
+    )
+
+
+@router.post("", response_model=AgentResponse, status_code=status.HTTP_201_CREATED)
+def create_agent(
+    data: AgentCreate,
+    user_id: UUID = Depends(get_current_user_id),
+    repository: AgentRepositoryImpl = Depends(get_repository),
+) -> AgentResponse:
+    """エージェントを作成する."""
+    use_case = CreateAgentUseCase(repository)
+    agent = use_case.execute(
+        user_id=user_id,
+        name=data.name,
+        description=data.description,
+        slack_channel_id=data.slack_channel_id,
+    )
+    return _to_response(agent)
+
+
+@router.get("", response_model=list[AgentResponse])
+def get_agents(
+    user_id: UUID = Depends(get_current_user_id),
+    repository: AgentRepositoryImpl = Depends(get_repository),
+) -> list[AgentResponse]:
+    """エージェント一覧を取得する."""
+    use_case = GetAgentsUseCase(repository)
+    agents = use_case.execute(user_id)
+    return [_to_response(a) for a in agents]
+
+
+@router.get("/{agent_id}", response_model=AgentResponse)
+def get_agent(
+    agent_id: UUID,
+    user_id: UUID = Depends(get_current_user_id),
+    repository: AgentRepositoryImpl = Depends(get_repository),
+) -> AgentResponse:
+    """エージェントを取得する."""
+    use_case = GetAgentUseCase(repository)
+    agent = use_case.execute(agent_id, user_id)
+    if not agent:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Agent not found")
+    return _to_response(agent)
+
+
+@router.put("/{agent_id}", response_model=AgentResponse)
+def update_agent(
+    agent_id: UUID,
+    data: AgentUpdate,
+    user_id: UUID = Depends(get_current_user_id),
+    repository: AgentRepositoryImpl = Depends(get_repository),
+) -> AgentResponse:
+    """エージェントを更新する."""
+    use_case = UpdateAgentUseCase(repository)
+    agent = use_case.execute(
+        agent_id=agent_id,
+        user_id=user_id,
+        name=data.name,
+        description=data.description,
+        slack_channel_id=data.slack_channel_id,
+    )
+    if not agent:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Agent not found")
+    return _to_response(agent)
+
+
+@router.delete("/{agent_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_agent(
+    agent_id: UUID,
+    user_id: UUID = Depends(get_current_user_id),
+    repository: AgentRepositoryImpl = Depends(get_repository),
+) -> None:
+    """エージェントを削除する."""
+    use_case = DeleteAgentUseCase(repository)
+    deleted = use_case.execute(agent_id, user_id)
+    if not deleted:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Agent not found")

--- a/backend/src/presentation/api/v1/router.py
+++ b/backend/src/presentation/api/v1/router.py
@@ -1,7 +1,8 @@
 from fastapi import APIRouter
 
-from src.presentation.api.v1.endpoints import dictionary, health
+from src.presentation.api.v1.endpoints import agents, dictionary, health
 
 api_router = APIRouter()
 api_router.include_router(health.router, tags=["health"])
 api_router.include_router(dictionary.router)
+api_router.include_router(agents.router)

--- a/backend/src/presentation/schemas/agent.py
+++ b/backend/src/presentation/schemas/agent.py
@@ -1,0 +1,38 @@
+"""Pydantic schemas for Agent API.
+
+Request/Response schemas for agent endpoints.
+"""
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class AgentCreate(BaseModel):
+    """エージェント作成リクエスト."""
+
+    name: str = Field(..., min_length=1, max_length=100, description="エージェント名")
+    description: str | None = Field(None, max_length=500, description="エージェントの説明")
+    slack_channel_id: str | None = Field(None, description="SlackチャンネルID")
+
+
+class AgentUpdate(BaseModel):
+    """エージェント更新リクエスト."""
+
+    name: str | None = Field(None, min_length=1, max_length=100, description="エージェント名")
+    description: str | None = Field(None, max_length=500, description="エージェントの説明")
+    slack_channel_id: str | None = Field(None, description="SlackチャンネルID")
+
+
+class AgentResponse(BaseModel):
+    """エージェントレスポンス."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    name: str
+    description: str | None
+    slack_channel_id: str | None
+    created_at: datetime
+    updated_at: datetime | None

--- a/backend/tests/domain/entities/test_agent.py
+++ b/backend/tests/domain/entities/test_agent.py
@@ -1,0 +1,186 @@
+"""Unit tests for Agent entity.
+
+Tests for Agent domain entity following TDD Red-Green-Refactor process.
+"""
+
+from datetime import datetime
+from uuid import uuid4
+
+from src.domain.entities.agent import Agent
+
+
+class TestAgentCreation:
+    """Test Agent entity instantiation."""
+
+    def test_agent_creation_with_required_fields(self) -> None:
+        """Agentが必須フィールドで正しくインスタンス化できる"""
+        # Arrange
+        agent_id = uuid4()
+        user_id = uuid4()
+        name = "週次定例MTG"
+        created_at = datetime.now()
+
+        # Act
+        agent = Agent(
+            id=agent_id,
+            user_id=user_id,
+            name=name,
+            created_at=created_at,
+        )
+
+        # Assert
+        assert agent.id == agent_id
+        assert agent.user_id == user_id
+        assert agent.name == name
+        assert agent.description is None
+        assert agent.slack_channel_id is None
+        assert agent.created_at == created_at
+        assert agent.updated_at is None
+
+    def test_agent_creation_with_all_fields(self) -> None:
+        """Agentが全フィールドで正しくインスタンス化できる"""
+        # Arrange
+        agent_id = uuid4()
+        user_id = uuid4()
+        name = "プロダクトチーム定例"
+        description = "毎週月曜日のプロダクトチーム定例MTG"
+        slack_channel_id = "C0123456789"
+        created_at = datetime.now()
+        updated_at = datetime.now()
+
+        # Act
+        agent = Agent(
+            id=agent_id,
+            user_id=user_id,
+            name=name,
+            description=description,
+            slack_channel_id=slack_channel_id,
+            created_at=created_at,
+            updated_at=updated_at,
+        )
+
+        # Assert
+        assert agent.id == agent_id
+        assert agent.user_id == user_id
+        assert agent.name == name
+        assert agent.description == description
+        assert agent.slack_channel_id == slack_channel_id
+        assert agent.created_at == created_at
+        assert agent.updated_at == updated_at
+
+
+class TestAgentUpdateSlackChannel:
+    """Test Agent.update_slack_channel method."""
+
+    def test_update_slack_channel_sets_channel_id(self) -> None:
+        """update_slack_channelがチャンネルIDを正しく設定する"""
+        # Arrange
+        agent = Agent(
+            id=uuid4(),
+            user_id=uuid4(),
+            name="テストMTG",
+            created_at=datetime.now(),
+        )
+        channel_id = "C9876543210"
+
+        # Act
+        agent.update_slack_channel(channel_id)
+
+        # Assert
+        assert agent.slack_channel_id == channel_id
+        assert agent.updated_at is not None
+
+    def test_update_slack_channel_with_none_clears_channel(self) -> None:
+        """update_slack_channelにNoneを渡すとチャンネルIDがクリアされる"""
+        # Arrange
+        agent = Agent(
+            id=uuid4(),
+            user_id=uuid4(),
+            name="テストMTG",
+            slack_channel_id="C0123456789",
+            created_at=datetime.now(),
+        )
+
+        # Act
+        agent.update_slack_channel(None)
+
+        # Assert
+        assert agent.slack_channel_id is None
+        assert agent.updated_at is not None
+
+
+class TestAgentUpdateInfo:
+    """Test Agent.update_info method."""
+
+    def test_update_info_updates_name(self) -> None:
+        """update_infoが名前を正しく更新する"""
+        # Arrange
+        agent = Agent(
+            id=uuid4(),
+            user_id=uuid4(),
+            name="旧MTG名",
+            created_at=datetime.now(),
+        )
+
+        # Act
+        agent.update_info(name="新MTG名")
+
+        # Assert
+        assert agent.name == "新MTG名"
+        assert agent.updated_at is not None
+
+    def test_update_info_updates_description(self) -> None:
+        """update_infoが説明を正しく更新する"""
+        # Arrange
+        agent = Agent(
+            id=uuid4(),
+            user_id=uuid4(),
+            name="テストMTG",
+            created_at=datetime.now(),
+        )
+
+        # Act
+        agent.update_info(description="新しい説明文")
+
+        # Assert
+        assert agent.description == "新しい説明文"
+        assert agent.updated_at is not None
+
+    def test_update_info_updates_both_name_and_description(self) -> None:
+        """update_infoが名前と説明の両方を同時に更新する"""
+        # Arrange
+        agent = Agent(
+            id=uuid4(),
+            user_id=uuid4(),
+            name="旧MTG名",
+            description="旧説明",
+            created_at=datetime.now(),
+        )
+
+        # Act
+        agent.update_info(name="新MTG名", description="新説明")
+
+        # Assert
+        assert agent.name == "新MTG名"
+        assert agent.description == "新説明"
+        assert agent.updated_at is not None
+
+    def test_update_info_with_none_does_not_change_existing_values(self) -> None:
+        """update_infoにNoneを渡しても既存の値は変更されない"""
+        # Arrange
+        agent = Agent(
+            id=uuid4(),
+            user_id=uuid4(),
+            name="テストMTG",
+            description="テスト説明",
+            created_at=datetime.now(),
+        )
+        original_name = agent.name
+        original_description = agent.description
+
+        # Act
+        agent.update_info(name=None, description=None)
+
+        # Assert
+        assert agent.name == original_name
+        assert agent.description == original_description

--- a/frontend/src/features/agents/AgentDetail.tsx
+++ b/frontend/src/features/agents/AgentDetail.tsx
@@ -1,0 +1,75 @@
+/**
+ * Agent detail page component
+ */
+
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import { useAgent, useDeleteAgent } from './hooks'
+
+export function AgentDetail() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const agentId = id ?? ''
+  const { data: agent, isLoading, error } = useAgent(agentId)
+  const deleteMutation = useDeleteAgent()
+
+  const handleDelete = async () => {
+    if (window.confirm('このエージェントを削除しますか？関連する議事録・アジェンダも削除されます。')) {
+      await deleteMutation.mutateAsync(agentId)
+      navigate('/agents')
+    }
+  }
+
+  if (!id) return <div className="p-4">エージェントIDが指定されていません</div>
+  if (isLoading) return <div className="p-4">読み込み中...</div>
+  if (error) return <div className="p-4 text-red-500">エラーが発生しました</div>
+  if (!agent) return <div className="p-4">エージェントが見つかりません</div>
+
+  return (
+    <div className="p-4">
+      <div className="mb-4">
+        <Link to="/agents" className="text-blue-500 hover:underline">
+          ← エージェント一覧に戻る
+        </Link>
+      </div>
+
+      <div className="bg-white rounded-lg border p-6">
+        <div className="flex justify-between items-start">
+          <div>
+            <h1 className="text-2xl font-bold">{agent.name}</h1>
+            {agent.description && <p className="text-gray-600 mt-2">{agent.description}</p>}
+          </div>
+          <button
+            type="button"
+            onClick={handleDelete}
+            className="text-red-500 hover:underline"
+            disabled={deleteMutation.isPending}
+          >
+            削除
+          </button>
+        </div>
+
+        {agent.slack_channel_id && (
+          <div className="mt-4 p-3 bg-gray-50 rounded">
+            <span className="text-sm text-gray-500">Slackチャンネル:</span>
+            <span className="ml-2">#{agent.slack_channel_id}</span>
+          </div>
+        )}
+
+        <div className="mt-6 flex gap-4">
+          <Link
+            to={`/agents/${agent.id}/meeting-notes`}
+            className="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600"
+          >
+            議事録一覧
+          </Link>
+          <Link
+            to={`/agents/${agent.id}/agendas/generate`}
+            className="bg-green-500 text-white px-4 py-2 rounded hover:bg-green-600"
+          >
+            アジェンダ生成
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/agents/AgentForm.tsx
+++ b/frontend/src/features/agents/AgentForm.tsx
@@ -1,0 +1,111 @@
+/**
+ * Agent create/edit form component
+ */
+
+import { useState } from 'react'
+import { useCreateAgent, useUpdateAgent } from './hooks'
+import type { Agent } from './types'
+
+interface Props {
+  agent: Agent | null
+  onClose: () => void
+}
+
+export function AgentForm({ agent, onClose }: Props) {
+  const [name, setName] = useState(agent?.name ?? '')
+  const [description, setDescription] = useState(agent?.description ?? '')
+  const [error, setError] = useState<string | null>(null)
+
+  const createMutation = useCreateAgent()
+  const updateMutation = useUpdateAgent()
+
+  const isEditing = !!agent
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+
+    if (!name.trim()) {
+      setError('エージェント名は必須です')
+      return
+    }
+
+    try {
+      if (isEditing) {
+        await updateMutation.mutateAsync({
+          id: agent.id,
+          data: {
+            name,
+            description: description || null,
+          },
+        })
+      } else {
+        await createMutation.mutateAsync({
+          name,
+          description: description || null,
+        })
+      }
+      onClose()
+    } catch (err) {
+      if (err instanceof Error) {
+        setError(err.message)
+      }
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-white rounded-lg p-6 w-full max-w-md">
+        <h2 className="text-xl font-bold mb-4">{isEditing ? 'エージェント編集' : 'エージェント作成'}</h2>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label htmlFor="agent-name" className="block text-sm font-medium mb-1">
+              エージェント名 <span className="text-red-500">*</span>
+            </label>
+            <input
+              id="agent-name"
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="w-full border rounded px-3 py-2"
+              required
+              maxLength={100}
+              placeholder="週次定例MTG"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="agent-description" className="block text-sm font-medium mb-1">
+              説明
+            </label>
+            <textarea
+              id="agent-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              className="w-full border rounded px-3 py-2"
+              maxLength={500}
+              rows={3}
+              placeholder="プロダクトチームの週次定例MTG"
+            />
+          </div>
+
+          {error && <div className="text-red-500 text-sm">{error}</div>}
+
+          <div className="flex justify-end gap-2">
+            <button type="button" onClick={onClose} className="px-4 py-2 border rounded hover:bg-gray-50">
+              キャンセル
+            </button>
+            <button
+              type="submit"
+              className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 disabled:opacity-50"
+              disabled={createMutation.isPending || updateMutation.isPending}
+            >
+              {isEditing ? '更新' : '作成'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/agents/AgentsPage.tsx
+++ b/frontend/src/features/agents/AgentsPage.tsx
@@ -1,0 +1,89 @@
+/**
+ * Agent list page component
+ */
+
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import { AgentForm } from './AgentForm'
+import { useAgents, useDeleteAgent } from './hooks'
+import type { Agent } from './types'
+
+export function AgentsPage() {
+  const [editingAgent, setEditingAgent] = useState<Agent | null>(null)
+  const [isFormOpen, setIsFormOpen] = useState(false)
+
+  const { data: agents, isLoading, error } = useAgents()
+  const deleteMutation = useDeleteAgent()
+
+  const handleDelete = async (id: string) => {
+    if (window.confirm('このエージェントを削除しますか？関連する議事録・アジェンダも削除されます。')) {
+      await deleteMutation.mutateAsync(id)
+    }
+  }
+
+  const handleEdit = (agent: Agent) => {
+    setEditingAgent(agent)
+    setIsFormOpen(true)
+  }
+
+  const handleCreate = () => {
+    setEditingAgent(null)
+    setIsFormOpen(true)
+  }
+
+  const handleFormClose = () => {
+    setEditingAgent(null)
+    setIsFormOpen(false)
+  }
+
+  if (isLoading) return <div className="p-4">読み込み中...</div>
+  if (error) return <div className="p-4 text-red-500">エラーが発生しました</div>
+
+  return (
+    <div className="p-4">
+      <div className="flex justify-between items-center mb-4">
+        <h1 className="text-2xl font-bold">MTGエージェント</h1>
+        <button
+          type="button"
+          onClick={handleCreate}
+          className="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600"
+        >
+          新規作成
+        </button>
+      </div>
+
+      {/* エージェント一覧 */}
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {agents?.map((agent) => (
+          <div key={agent.id} className="border rounded-lg p-4 hover:shadow-md transition-shadow">
+            <Link to={`/agents/${agent.id}`} className="font-bold text-lg hover:text-blue-500">
+              {agent.name}
+            </Link>
+            {agent.description && <p className="text-sm text-gray-600 mt-1">{agent.description}</p>}
+            {agent.slack_channel_id && <p className="text-xs text-gray-500 mt-2">Slack: #{agent.slack_channel_id}</p>}
+            <div className="flex gap-2 mt-4">
+              <button type="button" onClick={() => handleEdit(agent)} className="text-blue-500 hover:underline text-sm">
+                編集
+              </button>
+              <button
+                type="button"
+                onClick={() => handleDelete(agent.id)}
+                className="text-red-500 hover:underline text-sm"
+                disabled={deleteMutation.isPending}
+              >
+                削除
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {agents?.length === 0 && (
+        <div className="text-center text-gray-500 py-8">エージェントがありません。新規作成してください。</div>
+      )}
+
+      {/* フォームモーダル */}
+      {isFormOpen && <AgentForm agent={editingAgent} onClose={handleFormClose} />}
+    </div>
+  )
+}

--- a/frontend/src/features/agents/api.ts
+++ b/frontend/src/features/agents/api.ts
@@ -1,0 +1,36 @@
+/**
+ * Agent API functions
+ */
+
+import { apiClient } from '../../lib/api-client'
+import type { Agent, AgentCreate, AgentUpdate } from './types'
+
+const BASE_PATH = '/api/v1/agents'
+
+export async function getAgents(): Promise<Agent[]> {
+  return apiClient<Agent[]>(BASE_PATH)
+}
+
+export async function getAgent(id: string): Promise<Agent> {
+  return apiClient<Agent>(`${BASE_PATH}/${id}`)
+}
+
+export async function createAgent(data: AgentCreate): Promise<Agent> {
+  return apiClient<Agent>(BASE_PATH, {
+    method: 'POST',
+    body: JSON.stringify(data),
+  })
+}
+
+export async function updateAgent(id: string, data: AgentUpdate): Promise<Agent> {
+  return apiClient<Agent>(`${BASE_PATH}/${id}`, {
+    method: 'PUT',
+    body: JSON.stringify(data),
+  })
+}
+
+export async function deleteAgent(id: string): Promise<void> {
+  await apiClient<void>(`${BASE_PATH}/${id}`, {
+    method: 'DELETE',
+  })
+}

--- a/frontend/src/features/agents/hooks.ts
+++ b/frontend/src/features/agents/hooks.ts
@@ -1,0 +1,64 @@
+/**
+ * Agent TanStack Query hooks
+ */
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { createAgent, deleteAgent, getAgent, getAgents, updateAgent } from './api'
+import type { AgentCreate, AgentUpdate } from './types'
+
+export const agentKeys = {
+  all: ['agents'] as const,
+  lists: () => [...agentKeys.all, 'list'] as const,
+  list: () => [...agentKeys.lists()] as const,
+  details: () => [...agentKeys.all, 'detail'] as const,
+  detail: (id: string) => [...agentKeys.details(), id] as const,
+}
+
+export function useAgents() {
+  return useQuery({
+    queryKey: agentKeys.list(),
+    queryFn: getAgents,
+  })
+}
+
+export function useAgent(id: string) {
+  return useQuery({
+    queryKey: agentKeys.detail(id),
+    queryFn: () => getAgent(id),
+    enabled: !!id,
+  })
+}
+
+export function useCreateAgent() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (data: AgentCreate) => createAgent(data),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: agentKeys.lists() })
+    },
+  })
+}
+
+export function useUpdateAgent() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: AgentUpdate }) => updateAgent(id, data),
+    onSuccess: (_result, { id }) => {
+      void queryClient.invalidateQueries({ queryKey: agentKeys.lists() })
+      void queryClient.invalidateQueries({ queryKey: agentKeys.detail(id) })
+    },
+  })
+}
+
+export function useDeleteAgent() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (id: string) => deleteAgent(id),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: agentKeys.lists() })
+    },
+  })
+}

--- a/frontend/src/features/agents/index.ts
+++ b/frontend/src/features/agents/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Agent feature exports
+ */
+
+export { AgentDetail } from './AgentDetail'
+export { AgentForm } from './AgentForm'
+export { AgentsPage } from './AgentsPage'
+export { agentKeys, useAgent, useAgents, useCreateAgent, useDeleteAgent, useUpdateAgent } from './hooks'
+export type { Agent, AgentCreate, AgentUpdate } from './types'

--- a/frontend/src/features/agents/types.ts
+++ b/frontend/src/features/agents/types.ts
@@ -1,0 +1,24 @@
+/**
+ * Agent feature type definitions
+ */
+
+export interface Agent {
+  id: string
+  name: string
+  description: string | null
+  slack_channel_id: string | null
+  created_at: string
+  updated_at: string | null
+}
+
+export interface AgentCreate {
+  name: string
+  description?: string | null
+  slack_channel_id?: string | null
+}
+
+export interface AgentUpdate {
+  name?: string
+  description?: string | null
+  slack_channel_id?: string | null
+}

--- a/supabase/migrations/20260201013253_create_agents_table.sql
+++ b/supabase/migrations/20260201013253_create_agents_table.sql
@@ -1,0 +1,22 @@
+-- Create agents table for MTG agent management
+-- Phase 3: MTGエージェント機能
+
+CREATE TABLE IF NOT EXISTS public.agents (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    name VARCHAR(100) NOT NULL,
+    description VARCHAR(500),
+    slack_channel_id VARCHAR(50),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ
+);
+
+-- Create indexes
+CREATE INDEX IF NOT EXISTS idx_agents_user_id ON public.agents(user_id);
+
+-- Enable Row Level Security
+ALTER TABLE public.agents ENABLE ROW LEVEL SECURITY;
+
+-- RLS Policy: Users can only manage their own agents
+CREATE POLICY "Users can manage own agents" ON public.agents
+    FOR ALL USING (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- MTGエージェント管理機能をクリーンアーキテクチャ（ADR-0001準拠）で実装
- フルスタック実装（バックエンド + フロントエンド + DB マイグレーション）
- TDDプロセス（Red-Green-Refactor）に従った開発

## 変更内容

### バックエンド
- **Domain層**: `Agent` エンティティ、`AgentRepository` インターフェース
- **Infrastructure層**: `agents` テーブルマイグレーション（RLSポリシー含む）、`AgentRepositoryImpl`
- **Application層**: CRUD ユースケース（Create/Get/Update/Delete）
- **Presentation層**: REST API エンドポイント（`/api/v1/agents`）

### フロントエンド
- TanStack Query による状態管理
- エージェント一覧/作成/編集/詳細画面
- 型安全なAPI クライアント

### データベース
- `agents` テーブル（UUID主キー、RLS有効）
- `ON DELETE CASCADE` による関連データ削除

## Test plan
- [x] ドメイン層単体テスト（8件パス）
- [x] バックエンド品質チェック（ruff/mypy）
- [x] フロントエンド品質チェック（biome/tsc）
- [ ] 統合テスト（既存スケルトン: AC1/AC4）
- [ ] E2Eテスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)