### PR TITLE
feat: カレンダー同期改善・OAuthリダイレクト動的化・トランスクリプトAPI簡素化

### DIFF
--- a/backend/src/domain/entities/oauth_state.py
+++ b/backend/src/domain/entities/oauth_state.py
@@ -31,6 +31,7 @@ class OAuthState:
     user_id: UUID
     provider: str  # 'slack' | 'google'
     scopes: list[str] | None
+    redirect_origin: str | None
     expires_at: datetime
     created_at: datetime
 

--- a/backend/src/domain/repositories/recurring_meeting_repository.py
+++ b/backend/src/domain/repositories/recurring_meeting_repository.py
@@ -153,6 +153,24 @@ class RecurringMeetingRepository(ABC):
         """
 
     @abstractmethod
+    async def delete_by_user_except_google_event_ids(
+        self,
+        user_id: UUID,
+        google_event_ids: list[str],
+    ) -> int:
+        """Delete recurring meetings not in the given google_event_ids list.
+
+        Used during sync to remove meetings that no longer exist in Google Calendar.
+
+        Args:
+            user_id: The user ID for RLS filtering.
+            google_event_ids: List of google_event_ids to keep.
+
+        Returns:
+            Number of deleted records.
+        """
+
+    @abstractmethod
     async def upsert(self, meeting: RecurringMeeting) -> RecurringMeeting:
         """Create or update a recurring meeting based on google_event_id.
 

--- a/backend/src/infrastructure/repositories/oauth_state_repository_impl.py
+++ b/backend/src/infrastructure/repositories/oauth_state_repository_impl.py
@@ -47,12 +47,13 @@ class OAuthStateRepositoryImpl:
             oauth_state.user_id,
         )
 
-        data = {
+        data: dict[str, Any] = {
             "id": str(oauth_state.id),
             "state": oauth_state.state,
             "user_id": str(oauth_state.user_id),
             "provider": oauth_state.provider,
             "scopes": oauth_state.scopes,
+            "redirect_origin": oauth_state.redirect_origin,
             "expires_at": oauth_state.expires_at.isoformat(),
             "created_at": oauth_state.created_at.isoformat(),
         }
@@ -120,12 +121,16 @@ class OAuthStateRepositoryImpl:
         # scopesの型変換: DBからはlist | Noneが返る
         scopes: list[str] | None = [str(s) for s in scopes_raw] if isinstance(scopes_raw, list) else None
 
+        redirect_origin_raw = data.get("redirect_origin")
+        redirect_origin: str | None = str(redirect_origin_raw) if redirect_origin_raw is not None else None
+
         return OAuthState(
             id=UUID(str(data["id"])),
             state=str(data["state"]),
             user_id=UUID(str(data["user_id"])),
             provider=str(data["provider"]),
             scopes=scopes,
+            redirect_origin=redirect_origin,
             expires_at=(
                 datetime.fromisoformat(str(expires_at_str)) if isinstance(expires_at_str, str) else datetime.now()
             ),

--- a/backend/tests/application/use_cases/test_calendar_use_cases.py
+++ b/backend/tests/application/use_cases/test_calendar_use_cases.py
@@ -1,0 +1,228 @@
+"""CalendarUseCases tests.
+
+Tests for SyncRecurringMeetingsUseCase including stale record deletion.
+All external dependencies are mocked.
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from src.application.use_cases import calendar_use_cases
+from src.application.use_cases.calendar_use_cases import SyncRecurringMeetingsUseCase
+from src.domain.entities.google_integration import GoogleIntegration
+from src.infrastructure.external.google_calendar_client import (
+    CalendarAttendee,
+    CalendarEvent,
+)
+from src.infrastructure.external.google_oauth_client import GoogleTokenResponse
+
+
+class TestSyncRecurringMeetingsUseCase:
+    """SyncRecurringMeetingsUseCaseのテスト"""
+
+    def _make_calendar_event(
+        self,
+        event_id: str = "event_1",
+        summary: str = "Weekly Standup",
+        status: str = "confirmed",
+    ) -> CalendarEvent:
+        """テスト用CalendarEventを作成するヘルパー"""
+        return CalendarEvent(
+            event_id=event_id,
+            summary=summary,
+            rrule="RRULE:FREQ=WEEKLY;BYDAY=MO",
+            attendees=[
+                CalendarAttendee(email="a@test.com"),
+                CalendarAttendee(email="b@test.com"),
+            ],
+            start_datetime=datetime(2026, 2, 10, 9, 0, tzinfo=UTC),
+            status=status,
+        )
+
+    def _make_integration(self) -> GoogleIntegration:
+        """テスト用GoogleIntegrationを作成するヘルパー"""
+        return GoogleIntegration(
+            id=uuid4(),
+            user_id=uuid4(),
+            email="test@example.com",
+            encrypted_refresh_token="encrypted_token",
+            granted_scopes=["https://www.googleapis.com/auth/calendar.readonly"],
+            created_at=datetime.now(UTC),
+            updated_at=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_execute_deletes_stale_meetings(self) -> None:
+        """Google Calendarに存在しないDBレコードが削除されること"""
+        # Arrange
+        user_id = uuid4()
+        integration = self._make_integration()
+        events = [self._make_calendar_event(event_id="event_active")]
+
+        mock_google_repo = AsyncMock()
+        mock_google_repo.get_all.return_value = [integration]
+
+        mock_meeting_repo = AsyncMock()
+        mock_meeting_repo.get_by_google_event_id.return_value = None
+        mock_meeting_repo.upsert.side_effect = lambda m: m
+        mock_meeting_repo.delete_by_user_except_google_event_ids.return_value = 2
+
+        mock_token_response = MagicMock(spec=GoogleTokenResponse)
+        mock_token_response.access_token = "fake_access_token"
+
+        with (
+            patch.object(
+                calendar_use_cases,
+                "decrypt_google_token",
+                return_value="decrypted_refresh_token",
+            ),
+            patch.object(
+                calendar_use_cases,
+                "GoogleOAuthClient",
+            ) as mock_oauth_cls,
+            patch.object(
+                calendar_use_cases,
+                "GoogleCalendarClient",
+            ) as mock_calendar_cls,
+        ):
+            mock_oauth_instance = AsyncMock()
+            mock_oauth_instance.refresh_access_token.return_value = mock_token_response
+            mock_oauth_cls.return_value = mock_oauth_instance
+
+            mock_calendar_instance = AsyncMock()
+            mock_calendar_instance.get_recurring_events.return_value = events
+            mock_calendar_cls.return_value = mock_calendar_instance
+
+            use_case = SyncRecurringMeetingsUseCase(mock_google_repo, mock_meeting_repo)
+
+            # Act
+            result = await use_case.execute(user_id)
+
+        # Assert
+        assert len(result) == 1
+        mock_meeting_repo.delete_by_user_except_google_event_ids.assert_called_once_with(user_id, ["event_active"])
+
+    @pytest.mark.asyncio
+    async def test_execute_passes_empty_list_when_no_events(self) -> None:
+        """Google Calendarにイベントがない場合、全DBレコードが削除対象になること"""
+        # Arrange
+        user_id = uuid4()
+        integration = self._make_integration()
+
+        mock_google_repo = AsyncMock()
+        mock_google_repo.get_all.return_value = [integration]
+
+        mock_meeting_repo = AsyncMock()
+        mock_meeting_repo.delete_by_user_except_google_event_ids.return_value = 5
+
+        mock_token_response = MagicMock(spec=GoogleTokenResponse)
+        mock_token_response.access_token = "fake_access_token"
+
+        with (
+            patch.object(
+                calendar_use_cases,
+                "decrypt_google_token",
+                return_value="decrypted_refresh_token",
+            ),
+            patch.object(
+                calendar_use_cases,
+                "GoogleOAuthClient",
+            ) as mock_oauth_cls,
+            patch.object(
+                calendar_use_cases,
+                "GoogleCalendarClient",
+            ) as mock_calendar_cls,
+        ):
+            mock_oauth_instance = AsyncMock()
+            mock_oauth_instance.refresh_access_token.return_value = mock_token_response
+            mock_oauth_cls.return_value = mock_oauth_instance
+
+            mock_calendar_instance = AsyncMock()
+            mock_calendar_instance.get_recurring_events.return_value = []
+            mock_calendar_cls.return_value = mock_calendar_instance
+
+            use_case = SyncRecurringMeetingsUseCase(mock_google_repo, mock_meeting_repo)
+
+            # Act
+            result = await use_case.execute(user_id)
+
+        # Assert
+        assert len(result) == 0
+        mock_meeting_repo.delete_by_user_except_google_event_ids.assert_called_once_with(user_id, [])
+
+    @pytest.mark.asyncio
+    async def test_execute_preserves_existing_agent_link_on_upsert(self) -> None:
+        """既存レコードのagent_id紐付けがupsert時に保持されること"""
+        # Arrange
+        from src.domain.entities.recurring_meeting import (
+            Attendee,
+            MeetingFrequency,
+            RecurringMeeting,
+        )
+
+        user_id = uuid4()
+        agent_id = uuid4()
+        meeting_id = uuid4()
+        integration = self._make_integration()
+        events = [self._make_calendar_event(event_id="event_linked")]
+
+        existing_meeting = RecurringMeeting(
+            id=meeting_id,
+            user_id=user_id,
+            google_event_id="event_linked",
+            title="Old Title",
+            rrule="RRULE:FREQ=WEEKLY;BYDAY=MO",
+            frequency=MeetingFrequency.WEEKLY,
+            attendees=[Attendee(email="a@test.com")],
+            next_occurrence=datetime(2026, 2, 10, 9, 0, tzinfo=UTC),
+            agent_id=agent_id,
+            created_at=datetime.now(UTC),
+        )
+
+        mock_google_repo = AsyncMock()
+        mock_google_repo.get_all.return_value = [integration]
+
+        mock_meeting_repo = AsyncMock()
+        mock_meeting_repo.get_by_google_event_id.return_value = existing_meeting
+        mock_meeting_repo.upsert.side_effect = lambda m: m
+        mock_meeting_repo.delete_by_user_except_google_event_ids.return_value = 0
+
+        mock_token_response = MagicMock(spec=GoogleTokenResponse)
+        mock_token_response.access_token = "fake_access_token"
+
+        with (
+            patch.object(
+                calendar_use_cases,
+                "decrypt_google_token",
+                return_value="decrypted_refresh_token",
+            ),
+            patch.object(
+                calendar_use_cases,
+                "GoogleOAuthClient",
+            ) as mock_oauth_cls,
+            patch.object(
+                calendar_use_cases,
+                "GoogleCalendarClient",
+            ) as mock_calendar_cls,
+        ):
+            mock_oauth_instance = AsyncMock()
+            mock_oauth_instance.refresh_access_token.return_value = mock_token_response
+            mock_oauth_cls.return_value = mock_oauth_instance
+
+            mock_calendar_instance = AsyncMock()
+            mock_calendar_instance.get_recurring_events.return_value = events
+            mock_calendar_cls.return_value = mock_calendar_instance
+
+            use_case = SyncRecurringMeetingsUseCase(mock_google_repo, mock_meeting_repo)
+
+            # Act
+            result = await use_case.execute(user_id)
+
+        # Assert
+        assert len(result) == 1
+        upserted_meeting = mock_meeting_repo.upsert.call_args[0][0]
+        assert upserted_meeting.agent_id == agent_id
+        assert upserted_meeting.id == meeting_id

--- a/backend/tests/application/use_cases/test_google_auth_use_cases.py
+++ b/backend/tests/application/use_cases/test_google_auth_use_cases.py
@@ -161,6 +161,7 @@ class TestHandleGoogleCallbackUseCase:
             user_id=user_id,
             provider="google",
             scopes=DEFAULT_SCOPES,
+            redirect_origin=None,
             expires_at=now + timedelta(minutes=5),
             created_at=now,
         )
@@ -197,12 +198,13 @@ class TestHandleGoogleCallbackUseCase:
             use_case = HandleGoogleCallbackUseCase(mock_repository, mock_oauth_state_repository)
 
             # Act
-            result = await use_case.execute(code, state)
+            integration, returned_state = await use_case.execute(code, state)
 
             # Assert
-            assert result.email == "test@example.com"
-            assert result.user_id == user_id
-            assert result.encrypted_refresh_token == "encrypted_token"
+            assert integration.email == "test@example.com"
+            assert integration.user_id == user_id
+            assert integration.encrypted_refresh_token == "encrypted_token"
+            assert returned_state.redirect_origin is None
             mock_repository.create.assert_called_once()
             mock_oauth_state_repository.cleanup_expired.assert_called_once()
 
@@ -221,6 +223,7 @@ class TestHandleGoogleCallbackUseCase:
             user_id=user_id,
             provider="google",
             scopes=DEFAULT_SCOPES,
+            redirect_origin=None,
             expires_at=now + timedelta(minutes=5),
             created_at=now,
         )
@@ -267,10 +270,10 @@ class TestHandleGoogleCallbackUseCase:
             use_case = HandleGoogleCallbackUseCase(mock_repository, mock_oauth_state_repository)
 
             # Act
-            result = await use_case.execute(code, state)
+            integration, _ = await use_case.execute(code, state)
 
             # Assert
-            assert result.encrypted_refresh_token == "new_encrypted_token"
+            assert integration.encrypted_refresh_token == "new_encrypted_token"
             mock_repository.update.assert_called_once()
             mock_repository.create.assert_not_called()
 
@@ -303,6 +306,7 @@ class TestHandleGoogleCallbackUseCase:
             user_id=user_id,
             provider="google",
             scopes=DEFAULT_SCOPES,
+            redirect_origin=None,
             expires_at=now - timedelta(minutes=1),  # Already expired
             created_at=now - timedelta(minutes=6),
         )
@@ -331,6 +335,7 @@ class TestHandleGoogleCallbackUseCase:
             user_id=user_id,
             provider="google",
             scopes=DEFAULT_SCOPES,
+            redirect_origin=None,
             expires_at=now + timedelta(minutes=5),
             created_at=now,
         )

--- a/backend/tests/infrastructure/external/test_google_calendar_client.py
+++ b/backend/tests/infrastructure/external/test_google_calendar_client.py
@@ -1,0 +1,299 @@
+"""GoogleCalendarClient tests.
+
+Tests for cancelled event filtering and status parsing.
+All external dependencies (httpx) are mocked.
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.infrastructure.external.google_calendar_client import (
+    CalendarEvent,
+    GoogleCalendarClient,
+)
+
+
+class TestCalendarEventStatus:
+    """CalendarEventのstatus属性テスト"""
+
+    def test_default_status_is_confirmed(self) -> None:
+        """デフォルトのstatusがconfirmedであること"""
+        event = CalendarEvent(
+            event_id="test_id",
+            summary="Test Meeting",
+            rrule="RRULE:FREQ=WEEKLY;BYDAY=MO",
+            attendees=[],
+            start_datetime=datetime.now(UTC),
+        )
+        assert event.status == "confirmed"
+
+    def test_status_can_be_set_to_cancelled(self) -> None:
+        """statusをcancelledに設定できること"""
+        event = CalendarEvent(
+            event_id="test_id",
+            summary="Test Meeting",
+            rrule="RRULE:FREQ=WEEKLY;BYDAY=MO",
+            attendees=[],
+            start_datetime=datetime.now(UTC),
+            status="cancelled",
+        )
+        assert event.status == "cancelled"
+
+
+class TestParseEventStatus:
+    """_parse_eventのstatus取得テスト"""
+
+    def test_parse_event_extracts_confirmed_status(self) -> None:
+        """confirmedステータスのイベントをパースできること"""
+        client = GoogleCalendarClient("fake_token")
+        item = {
+            "id": "event_123",
+            "summary": "Weekly Standup",
+            "status": "confirmed",
+            "recurrence": ["RRULE:FREQ=WEEKLY;BYDAY=MO"],
+            "start": {"dateTime": "2026-01-15T09:00:00+09:00"},
+            "attendees": [],
+        }
+        event = client._parse_event(item)
+        assert event is not None
+        assert event.status == "confirmed"
+
+    def test_parse_event_extracts_cancelled_status(self) -> None:
+        """cancelledステータスのイベントをパースできること"""
+        client = GoogleCalendarClient("fake_token")
+        item = {
+            "id": "event_456",
+            "summary": "Cancelled Meeting",
+            "status": "cancelled",
+            "recurrence": ["RRULE:FREQ=WEEKLY;BYDAY=TU"],
+            "start": {"dateTime": "2026-01-15T10:00:00+09:00"},
+            "attendees": [],
+        }
+        event = client._parse_event(item)
+        assert event is not None
+        assert event.status == "cancelled"
+
+    def test_parse_event_defaults_to_confirmed_when_no_status(self) -> None:
+        """statusフィールドがない場合、confirmedがデフォルトになること"""
+        client = GoogleCalendarClient("fake_token")
+        item = {
+            "id": "event_789",
+            "summary": "No Status Meeting",
+            "recurrence": ["RRULE:FREQ=WEEKLY;BYDAY=WE"],
+            "start": {"dateTime": "2026-01-15T11:00:00+09:00"},
+            "attendees": [],
+        }
+        event = client._parse_event(item)
+        assert event is not None
+        assert event.status == "confirmed"
+
+
+class TestGetRecurringEventsFiltersExceptionInstances:
+    """get_recurring_eventsの例外インスタンスフィルタリングテスト"""
+
+    @pytest.mark.asyncio
+    async def test_exception_instances_are_filtered_out(self) -> None:
+        """recurringEventIdを持つ例外インスタンスがフィルタリングされること"""
+        # Arrange
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "items": [
+                {
+                    "id": "base_event_123",
+                    "summary": "Weekly Standup",
+                    "status": "confirmed",
+                    "recurrence": ["RRULE:FREQ=WEEKLY;BYDAY=MO"],
+                    "start": {"dateTime": "2026-01-15T09:00:00+09:00"},
+                    "attendees": [
+                        {"email": "a@test.com"},
+                        {"email": "b@test.com"},
+                    ],
+                },
+                {
+                    "id": "base_event_123_R20260122T090000",
+                    "summary": "Weekly Standup",
+                    "status": "confirmed",
+                    "recurringEventId": "base_event_123",
+                    "recurrence": ["RRULE:FREQ=WEEKLY;BYDAY=MO"],
+                    "start": {"dateTime": "2026-01-22T09:00:00+09:00"},
+                    "attendees": [
+                        {"email": "a@test.com"},
+                        {"email": "b@test.com"},
+                    ],
+                },
+            ],
+        }
+
+        mock_http_client = AsyncMock()
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+
+        client = GoogleCalendarClient("fake_token")
+
+        with patch("src.infrastructure.external.google_calendar_client.httpx.AsyncClient") as mock_cls:
+            mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_http_client)
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            # Act
+            events = await client.get_recurring_events(min_attendees=2)
+
+        # Assert: only the base event should be returned
+        assert len(events) == 1
+        assert events[0].event_id == "base_event_123"
+
+
+class TestGetRecurringEventsPagination:
+    """get_recurring_eventsのページネーションテスト"""
+
+    @pytest.mark.asyncio
+    async def test_fetches_all_pages(self) -> None:
+        """nextPageTokenがある場合に全ページを取得すること"""
+        # Arrange
+        page1_response = MagicMock()
+        page1_response.status_code = 200
+        page1_response.json.return_value = {
+            "items": [
+                {
+                    "id": "event_page1",
+                    "summary": "Page 1 Meeting",
+                    "status": "confirmed",
+                    "recurrence": ["RRULE:FREQ=WEEKLY;BYDAY=MO"],
+                    "start": {"dateTime": "2026-01-15T09:00:00+09:00"},
+                    "attendees": [
+                        {"email": "a@test.com"},
+                        {"email": "b@test.com"},
+                    ],
+                },
+            ],
+            "nextPageToken": "token_page2",
+        }
+
+        page2_response = MagicMock()
+        page2_response.status_code = 200
+        page2_response.json.return_value = {
+            "items": [
+                {
+                    "id": "event_page2",
+                    "summary": "Page 2 Meeting",
+                    "status": "confirmed",
+                    "recurrence": ["RRULE:FREQ=WEEKLY;BYDAY=TU"],
+                    "start": {"dateTime": "2026-01-16T10:00:00+09:00"},
+                    "attendees": [
+                        {"email": "c@test.com"},
+                        {"email": "d@test.com"},
+                    ],
+                },
+            ],
+        }
+
+        mock_http_client = AsyncMock()
+        mock_http_client.get = AsyncMock(side_effect=[page1_response, page2_response])
+
+        client = GoogleCalendarClient("fake_token")
+
+        with patch("src.infrastructure.external.google_calendar_client.httpx.AsyncClient") as mock_cls:
+            mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_http_client)
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            # Act
+            events = await client.get_recurring_events(min_attendees=2)
+
+        # Assert: events from both pages should be returned
+        assert len(events) == 2
+        assert events[0].event_id == "event_page1"
+        assert events[1].event_id == "event_page2"
+        assert mock_http_client.get.call_count == 2
+
+
+class TestGetRecurringEventsFiltersCancelled:
+    """get_recurring_eventsのcancelledイベントフィルタリングテスト"""
+
+    @pytest.mark.asyncio
+    async def test_cancelled_events_are_filtered_out(self) -> None:
+        """cancelledイベントがフィルタリングされること"""
+        # Arrange
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "items": [
+                {
+                    "id": "confirmed_event",
+                    "summary": "Active Weekly",
+                    "status": "confirmed",
+                    "recurrence": ["RRULE:FREQ=WEEKLY;BYDAY=MO"],
+                    "start": {"dateTime": "2026-01-15T09:00:00+09:00"},
+                    "attendees": [
+                        {"email": "a@test.com"},
+                        {"email": "b@test.com"},
+                    ],
+                },
+                {
+                    "id": "cancelled_event",
+                    "summary": "Cancelled Weekly",
+                    "status": "cancelled",
+                    "recurrence": ["RRULE:FREQ=WEEKLY;BYDAY=TU"],
+                    "start": {"dateTime": "2026-01-15T10:00:00+09:00"},
+                    "attendees": [
+                        {"email": "a@test.com"},
+                        {"email": "b@test.com"},
+                    ],
+                },
+            ]
+        }
+
+        mock_http_client = AsyncMock()
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+
+        client = GoogleCalendarClient("fake_token")
+
+        with patch("src.infrastructure.external.google_calendar_client.httpx.AsyncClient") as mock_cls:
+            mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_http_client)
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            # Act
+            events = await client.get_recurring_events(min_attendees=2)
+
+        # Assert
+        assert len(events) == 1
+        assert events[0].event_id == "confirmed_event"
+        assert events[0].status == "confirmed"
+
+    @pytest.mark.asyncio
+    async def test_tentative_events_are_not_filtered(self) -> None:
+        """tentativeイベントはフィルタリングされないこと"""
+        # Arrange
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "items": [
+                {
+                    "id": "tentative_event",
+                    "summary": "Tentative Weekly",
+                    "status": "tentative",
+                    "recurrence": ["RRULE:FREQ=WEEKLY;BYDAY=FR"],
+                    "start": {"dateTime": "2026-01-17T14:00:00+09:00"},
+                    "attendees": [
+                        {"email": "a@test.com"},
+                        {"email": "b@test.com"},
+                    ],
+                },
+            ]
+        }
+
+        mock_http_client = AsyncMock()
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+
+        client = GoogleCalendarClient("fake_token")
+
+        with patch("src.infrastructure.external.google_calendar_client.httpx.AsyncClient") as mock_cls:
+            mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_http_client)
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            # Act
+            events = await client.get_recurring_events(min_attendees=2)
+
+        # Assert
+        assert len(events) == 1
+        assert events[0].status == "tentative"

--- a/backend/tests/integration/test_google.py
+++ b/backend/tests/integration/test_google.py
@@ -193,6 +193,7 @@ class TestGoogleIntegration:
                 user_id=TEST_USER_ID,
                 provider="google",
                 scopes=["openid", "email", "profile"],
+                redirect_origin=None,
                 expires_at=now + timedelta(minutes=5),
                 created_at=now,
             )

--- a/frontend/src/features/agents/AgentDetailPage.tsx
+++ b/frontend/src/features/agents/AgentDetailPage.tsx
@@ -2,7 +2,7 @@
  * Agent detail page - Shows agent info, meeting notes, and Slack integration
  */
 import { useEffect, useMemo, useState } from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
+import { Link, useNavigate, useParams } from 'react-router-dom'
 import { AgentAvatar, Button, Card, EmptyState, Modal, SlackIcon } from '../../components/ui'
 import { AgendaGeneratePage } from '../agendas'
 import { DictionarySection } from '../dictionary/DictionarySection'
@@ -1022,7 +1022,10 @@ export function AgentDetailPage() {
                         borderRadius: 'var(--radius-md)',
                       }}
                     >
-                      <div>
+                      <Link
+                        to={`/meetings/${meeting.id}/transcripts`}
+                        style={{ textDecoration: 'none', color: 'inherit' }}
+                      >
                         <div style={{ fontWeight: 600, color: 'var(--color-warm-gray-700)' }}>{meeting.title}</div>
                         <div
                           style={{
@@ -1036,8 +1039,12 @@ export function AgentDetailPage() {
                           {meeting.frequency === 'monthly' && '毎月'}
                           {' • '}
                           {meeting.attendees.length}名参加
+                          {' • '}
+                          <span style={{ color: 'var(--color-primary)', textDecoration: 'underline' }}>
+                            議事録を表示
+                          </span>
                         </div>
-                      </div>
+                      </Link>
                       <Button
                         variant="ghost"
                         onClick={() => handleUnlinkMeeting(meeting.id)}

--- a/frontend/src/features/google/api.ts
+++ b/frontend/src/features/google/api.ts
@@ -1,6 +1,5 @@
 import { apiClient } from '../../lib/api-client'
 import type {
-  DriveScopesResponse,
   GoogleIntegration,
   GoogleOAuthStartResponse,
   LinkRecurringMeetingResponse,
@@ -8,14 +7,15 @@ import type {
   RecurringMeeting,
   SyncProviderTokenRequest,
   SyncProviderTokenResponse,
-  TranscriptsResponse,
+  SyncResultResponse,
   UnlinkRecurringMeetingResponse,
 } from './types'
 
 const BASE_PATH = '/api/v1/google'
 
 export async function startGoogleOAuth(): Promise<GoogleOAuthStartResponse> {
-  return apiClient<GoogleOAuthStartResponse>(`${BASE_PATH}/auth`)
+  const params = new URLSearchParams({ redirect_origin: window.location.origin })
+  return apiClient<GoogleOAuthStartResponse>(`${BASE_PATH}/auth?${params.toString()}`)
 }
 
 export async function getGoogleIntegrations(): Promise<GoogleIntegration[]> {
@@ -36,26 +36,26 @@ export async function syncProviderToken(request: SyncProviderTokenRequest): Prom
 }
 
 export async function startAdditionalScopes(integrationId: string): Promise<GoogleOAuthStartResponse> {
-  return apiClient<GoogleOAuthStartResponse>(`${BASE_PATH}/auth/additional-scopes?integration_id=${integrationId}`)
+  const params = new URLSearchParams({
+    integration_id: integrationId,
+    redirect_origin: window.location.origin,
+  })
+  return apiClient<GoogleOAuthStartResponse>(`${BASE_PATH}/auth/additional-scopes?${params.toString()}`)
 }
 
-export async function checkDriveScopes(integrationId: string): Promise<DriveScopesResponse> {
-  return apiClient<DriveScopesResponse>(`${BASE_PATH}/auth/check-drive-scopes?integration_id=${integrationId}`)
+// Transcript API functions
+const TRANSCRIPTS_PATH = '/api/v1/transcripts'
+
+export async function getTranscripts(recurringMeetingId: string): Promise<MeetingTranscript[]> {
+  return apiClient<MeetingTranscript[]>(`${TRANSCRIPTS_PATH}?recurring_meeting_id=${recurringMeetingId}`)
 }
 
-export async function getTranscripts(recurringMeetingId: string): Promise<TranscriptsResponse> {
-  return apiClient<TranscriptsResponse>(`${BASE_PATH}/transcripts?recurring_meeting_id=${recurringMeetingId}`)
-}
-
-export async function syncTranscripts(integrationId: string, recurringMeetingId: string): Promise<TranscriptsResponse> {
-  return apiClient<TranscriptsResponse>(
-    `${BASE_PATH}/transcripts/sync?integration_id=${integrationId}&recurring_meeting_id=${recurringMeetingId}`,
-    { method: 'POST' },
-  )
+export async function syncTranscripts(): Promise<SyncResultResponse> {
+  return apiClient<SyncResultResponse>(`${TRANSCRIPTS_PATH}/sync`, { method: 'POST' })
 }
 
 export async function linkTranscript(transcriptId: string, recurringMeetingId: string): Promise<MeetingTranscript> {
-  return apiClient<MeetingTranscript>(`${BASE_PATH}/transcripts/${transcriptId}/link`, {
+  return apiClient<MeetingTranscript>(`${TRANSCRIPTS_PATH}/${transcriptId}/link`, {
     method: 'POST',
     body: JSON.stringify({ recurring_meeting_id: recurringMeetingId }),
   })

--- a/frontend/src/features/google/index.ts
+++ b/frontend/src/features/google/index.ts
@@ -1,9 +1,9 @@
 export { GoogleIntegrationPage } from './GoogleIntegrationPage'
 export {
   googleKeys,
+  hasDriveScopes,
   useAgentRecurringMeetings,
   useDeleteGoogleIntegration,
-  useDriveScopes,
   useGoogleIntegrations,
   useLinkRecurringMeeting,
   useLinkTranscript,
@@ -20,7 +20,6 @@ export { TranscriptViewer } from './TranscriptViewer'
 export type {
   AgentRecurringMeetingsResponse,
   Attendee,
-  DriveScopesResponse,
   GoogleIntegration,
   GoogleOAuthStartResponse,
   LinkRecurringMeetingRequest,
@@ -28,8 +27,8 @@ export type {
   MeetingFrequency,
   MeetingTranscript,
   RecurringMeeting,
+  SyncResultResponse,
   TranscriptEntry,
   TranscriptStructuredData,
-  TranscriptsResponse,
   UnlinkRecurringMeetingResponse,
 } from './types'

--- a/frontend/src/features/google/types.ts
+++ b/frontend/src/features/google/types.ts
@@ -35,14 +35,12 @@ export interface MeetingTranscript {
   needs_manual_confirmation: boolean
 }
 
-/** トランスクリプト一覧レスポンス */
-export interface TranscriptsResponse {
-  transcripts: MeetingTranscript[]
-}
-
-/** Driveスコープ確認レスポンス */
-export interface DriveScopesResponse {
-  has_drive_scopes: boolean
+/** 同期結果レスポンス */
+export interface SyncResultResponse {
+  synced_count: number
+  skipped_count: number
+  error_count: number
+  synced_transcripts: MeetingTranscript[]
 }
 
 /** 参加者情報 */

--- a/frontend/src/features/slack/api.ts
+++ b/frontend/src/features/slack/api.ts
@@ -4,7 +4,8 @@ import type { SlackChannel, SlackIntegration, SlackMessage, SlackOAuthStartRespo
 const BASE_PATH = '/api/v1/slack'
 
 export async function startSlackOAuth(): Promise<SlackOAuthStartResponse> {
-  return apiClient<SlackOAuthStartResponse>(`${BASE_PATH}/auth`)
+  const params = new URLSearchParams({ redirect_origin: window.location.origin })
+  return apiClient<SlackOAuthStartResponse>(`${BASE_PATH}/auth?${params.toString()}`)
 }
 
 export async function getSlackIntegrations(): Promise<SlackIntegration[]> {

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -7,4 +7,30 @@ if (!supabaseUrl || !supabaseKey) {
   throw new Error('Missing Supabase environment variables: VITE_SUPABASE_URL and VITE_SUPABASE_KEY are required')
 }
 
-export const supabase = createClient(supabaseUrl, supabaseKey)
+// Cookieベースのストレージ（localStorageの問題を回避）
+const cookieStorage = {
+  getItem: (key: string): string | null => {
+    const cookies = document.cookie.split(';')
+    for (const cookie of cookies) {
+      const [name, value] = cookie.trim().split('=')
+      if (name === key) {
+        return decodeURIComponent(value)
+      }
+    }
+    return null
+  },
+  setItem: (key: string, value: string): void => {
+    // 7日間有効、SameSite=Laxでセキュリティを確保
+    document.cookie = `${key}=${encodeURIComponent(value)}; path=/; max-age=${60 * 60 * 24 * 7}; SameSite=Lax`
+  },
+  removeItem: (key: string): void => {
+    document.cookie = `${key}=; path=/; max-age=0`
+  },
+}
+
+export const supabase = createClient(supabaseUrl, supabaseKey, {
+  auth: {
+    storage: cookieStorage,
+    detectSessionInUrl: false,
+  },
+})

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -7,30 +7,4 @@ if (!supabaseUrl || !supabaseKey) {
   throw new Error('Missing Supabase environment variables: VITE_SUPABASE_URL and VITE_SUPABASE_KEY are required')
 }
 
-// Cookieベースのストレージ（localStorageの問題を回避）
-const cookieStorage = {
-  getItem: (key: string): string | null => {
-    const cookies = document.cookie.split(';')
-    for (const cookie of cookies) {
-      const [name, value] = cookie.trim().split('=')
-      if (name === key) {
-        return decodeURIComponent(value)
-      }
-    }
-    return null
-  },
-  setItem: (key: string, value: string): void => {
-    // 7日間有効、SameSite=Laxでセキュリティを確保
-    document.cookie = `${key}=${encodeURIComponent(value)}; path=/; max-age=${60 * 60 * 24 * 7}; SameSite=Lax`
-  },
-  removeItem: (key: string): void => {
-    document.cookie = `${key}=; path=/; max-age=0`
-  },
-}
-
-export const supabase = createClient(supabaseUrl, supabaseKey, {
-  auth: {
-    storage: cookieStorage,
-    detectSessionInUrl: false,
-  },
-})
+export const supabase = createClient(supabaseUrl, supabaseKey)

--- a/supabase/migrations/20260209000000_add_redirect_origin_to_oauth_states.sql
+++ b/supabase/migrations/20260209000000_add_redirect_origin_to_oauth_states.sql
@@ -1,0 +1,6 @@
+-- oauth_statesテーブルにredirect_originカラムを追加
+-- OAuth callback後のリダイレクト先をstate毎に動的に決定するため
+-- NULLable: 既存レコードとの互換性、および未指定時はフォールバック使用
+
+ALTER TABLE public.oauth_states
+    ADD COLUMN redirect_origin TEXT;


### PR DESCRIPTION
## Summary

- **OAuthリダイレクト動的化**: OAuth stateに`redirect_origin`を保存し、callback後のリダイレクト先をリクエスト元オリジンに基づいて動的決定（Vercel Preview等の複数環境対応）
- **カレンダー同期改善**: Google Calendar APIのページネーション対応、キャンセル済み/例外イベントのフィルタ、同期時に不要な定例MTGの自動削除、最小参加者数を1に変更
- **トランスクリプトAPI簡素化**: integration_idパラメータ不要化、Driveスコープ確認をクライアント側で実施、APIパスを`/api/v1/transcripts`に変更
- **Slack APIエラーハンドリング追加**: レートリミット(429)とAPI エラー(502)の適切なHTTPレスポンス
- **Supabaseストレージ**: cookieベースからデフォルト(localStorage)に復帰
- **UI改善**: エージェント詳細ページに議事録リンクを追加

## Changes

### Backend
- `oauth_states`テーブルに`redirect_origin`カラム追加（マイグレーション含む）
- `OAuthState`エンティティに`redirect_origin`フィールド追加
- Google/Slack OAuth開始時に`redirect_origin`をバリデーション（CORS許可リスト照合）
- コールバック時に`redirect_origin`からリダイレクト先を決定
- `HandleGoogleCallbackUseCase`/`HandleSlackCallbackUseCase`の返り値をtuple化
- `GoogleCalendarClient`にページネーション、キャンセル済みイベント除外、例外インスタンス除外を追加
- `RecurringMeetingRepository`に`delete_by_user_except_google_event_ids`メソッド追加
- Slack APIエンドポイントに`SlackApiError`ハンドリング追加
- ユニットテスト追加（calendar_use_cases, google_calendar_client）

### Frontend
- OAuth開始時に`redirect_origin=window.location.origin`をクエリパラメータとして送信
- `useDriveScopes` hook → `hasDriveScopes`純関数に変更（API呼び出し削減）
- `syncTranscripts`からintegrationId/recurringMeetingIdパラメータを削除
- Supabase clientからcookieストレージ設定を削除（デフォルトに復帰）
- エージェント詳細ページの定例MTGに議事録リンクを追加

## Test plan

- [ ] Google OAuth認証→正しいオリジンにリダイレクトされること
- [ ] Slack OAuth認証→正しいオリジンにリダイレクトされること
- [ ] カレンダー同期→250件超のイベントでもページネーションで全取得されること
- [ ] カレンダー同期→キャンセル済みイベントが除外されること
- [ ] カレンダー同期→Google Calendar上で削除したイベントがDB上でも削除されること
- [ ] 議事録同期→integrationId不要で動作すること
- [ ] エージェント詳細→定例MTGから議事録ページに遷移できること
- [ ] `uv run pytest` が全テストパスすること
- [ ] `npm run type-check && npm run check` がパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)